### PR TITLE
chore: 更换npm镜像源为国内镜像

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,4 +5,4 @@
 #electron_builder_binaries_mirror=https://npmmirror.com/mirrors/electron-builder-binaries/
 
 # 国内依赖镜像源
-registry=https://registry.npmjs.org
+registry=https://registry.npmmirror.com


### PR DESCRIPTION
将npm注册表从官方源切换到npmmirror国内源，加速依赖包下载