### PR TITLE
chore(.npmrc): 注释掉国内依赖镜像源配置

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,4 +5,4 @@
 #electron_builder_binaries_mirror=https://npmmirror.com/mirrors/electron-builder-binaries/
 
 # 国内依赖镜像源
-registry=https://registry.npmmirror.com
+# registry=https://registry.npmmirror.com

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,5 +9,6 @@
     "scripts": {},
     "build": {},
     "devDependencies": {},
-    "dependencies": {}
+    "dependencies": {},
+    "packageManager": "pnpm@8.12.1"
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -7,5 +7,6 @@
   "private": true,
   "scripts": {},
   "dependencies": {},
+  "packageManager": "pnpm@8.12.1",
   "devDependencies": {}
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,5 +9,6 @@
         "dev": "vite --config vite.config.ts",
         "build": "vite build --config vite.config.ts",
         "preview": "vite preview --config vite.config.ts"
-    }
+    },
+    "packageManager": "pnpm@8.12.1"
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "private": true,
     "type": "module",
+    "packageManager": "pnpm@8.12.1",
     "scripts": {
         "webapp": "pnpm --filter @nao-todo/webapp",
         "mobile": "pnpm --filter @nao-todo/mobile",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -5,5 +5,6 @@
     "license": "MIT",
     "files": [
         "web/*"
-    ]
+    ],
+    "packageManager": "pnpm@8.12.1"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5,5 +5,6 @@
     "license": "MIT",
     "main": "index.ts",
     "private": true,
-    "type": "module"
+    "type": "module",
+    "packageManager": "pnpm@8.12.1"
 }

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -12,5 +12,6 @@
         "tag",
         "task",
         "user"
-    ]
+    ],
+    "packageManager": "pnpm@8.12.1"
 }

--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -11,8 +11,8 @@
         "locales/**/*",
         "utils/**/*"
     ],
+    "packageManager": "pnpm@8.12.1",
     "peerDependencies": {
         "vue": "^3"
     }
 }
-

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,5 +4,6 @@
     "version": "0.1.0",
     "author": "Nathan Lee",
     "license": "MIT",
-    "main": "index.ts"
+    "main": "index.ts",
+    "packageManager": "pnpm@8.12.1"
 }


### PR DESCRIPTION
将registry镜像源配置行注释，暂时不使用国内镜像源